### PR TITLE
Add splitting functionality

### DIFF
--- a/src/cards.rs
+++ b/src/cards.rs
@@ -23,7 +23,7 @@ impl Display for Suit {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Rank {
     Ace,
     Two,

--- a/src/cards.rs
+++ b/src/cards.rs
@@ -82,6 +82,10 @@ impl Hand {
         Hand { cards: Vec::new() }
     }
 
+    pub fn add_card(&mut self, card: Card) {
+        self.cards.push(card);
+    }
+
     pub fn score(&self) -> i32 {
         let mut score = 0;
         let mut aces = 0;

--- a/src/cards.rs
+++ b/src/cards.rs
@@ -75,11 +75,15 @@ impl Display for Card {
 
 pub struct Hand {
     pub cards: Vec<Card>,
+    pub multiplier: f32,
 }
 
 impl Hand {
     pub fn new() -> Self {
-        Hand { cards: Vec::new() }
+        Hand {
+            cards: Vec::new(),
+            multiplier: 1.0,
+        }
     }
 
     pub fn add_card(&mut self, card: Card) {
@@ -131,6 +135,11 @@ impl Hand {
             aces -= 1;
         }
         score
+    }
+
+    // indicates whether hand is splittable
+    pub fn can_split(&self) -> bool {
+        self.cards[0].rank == self.cards[1].rank
     }
 }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,4 +1,4 @@
-use crate::cards::{Card, Hand, Shoe};
+use crate::cards::{Hand, Shoe};
 use std::io;
 
 pub struct Player {
@@ -8,10 +8,6 @@ pub struct Player {
 impl Player {
     pub fn new() -> Self {
         Player { hand: Hand::new() }
-    }
-
-    pub fn add_card(&mut self, card: Card) {
-        self.hand.cards.push(card);
     }
 }
 
@@ -24,10 +20,10 @@ pub fn play_hand(shoe: &mut Shoe) -> f32 {
     // this will increase to 2 if doubled down
     let mut multiplier: f32 = 1.0;
     // deal initial cards
-    player.add_card(shoe.deal().unwrap());
-    dealer.add_card(shoe.deal().unwrap());
-    player.add_card(shoe.deal().unwrap());
-    dealer.add_card(shoe.deal().unwrap());
+    player.hand.add_card(shoe.deal().unwrap());
+    dealer.hand.add_card(shoe.deal().unwrap());
+    player.hand.add_card(shoe.deal().unwrap());
+    dealer.hand.add_card(shoe.deal().unwrap());
 
     println!("Hand: {}", player.hand);
     println!("Score: {:?}", player.hand.score());
@@ -61,7 +57,7 @@ pub fn play_hand(shoe: &mut Shoe) -> f32 {
 
         match decision {
             ("h", _) => {
-                player.add_card(shoe.deal().unwrap());
+                player.hand.add_card(shoe.deal().unwrap());
                 println!("Hand: {}", player.hand);
                 println!("Score: {:?}", player.hand.score());
                 if player.hand.score() > 21 {
@@ -72,7 +68,7 @@ pub fn play_hand(shoe: &mut Shoe) -> f32 {
             }
             ("d", 1) => {
                 multiplier = 2.0;
-                player.add_card(shoe.deal().unwrap());
+                player.hand.add_card(shoe.deal().unwrap());
                 println!("Hand: {}", player.hand);
                 println!("Score: {:?}", player.hand.score());
                 if player.hand.score() > 21 {
@@ -97,7 +93,7 @@ pub fn play_hand(shoe: &mut Shoe) -> f32 {
     // dealer's turn
     println!("Dealer: {}", dealer.hand);
     while dealer.hand.score() < 17 {
-        dealer.add_card(shoe.deal().unwrap());
+        dealer.hand.add_card(shoe.deal().unwrap());
         println!("Dealer: {}", dealer.hand);
     }
     println!("Dealer score: {}", dealer.hand.score());

--- a/src/game.rs
+++ b/src/game.rs
@@ -2,41 +2,23 @@ use crate::cards::{Hand, Shoe};
 use std::io;
 
 pub struct Player {
-    pub hand: Hand,
+    pub hands: Vec<Hand>,
 }
 
 impl Player {
     pub fn new() -> Self {
-        Player { hand: Hand::new() }
+        Player {
+            hands: vec![Hand::new()],
+        }
     }
 }
 
-pub fn play_hand(shoe: &mut Shoe) -> f32 {
-    //instantiate players
-    let mut player = Player::new();
-    let mut dealer = Player::new();
-
+fn settle_player_hand<'a>(shoe: &'a mut Shoe, player: &'a mut Hand) -> f32 {
+    //(&mut Hand, f32)
     // set initial hand multiplier to 1
     // this will increase to 2 if doubled down
     let mut multiplier: f32 = 1.0;
-    // deal initial cards
-    player.hand.add_card(shoe.deal().unwrap());
-    dealer.hand.add_card(shoe.deal().unwrap());
-    player.hand.add_card(shoe.deal().unwrap());
-    dealer.hand.add_card(shoe.deal().unwrap());
-
-    println!("Hand: {}", player.hand);
-    println!("Score: {:?}", player.hand.score());
-
-    if player.hand.score() == 21 {
-        println!("Blackjack!");
-        return 1.5;
-    }
-
-    // print dealer's up card
-    println!("Dealer: {}", dealer.hand.cards[0]);
-
-    //player's turn
+    // player's turn
     let mut counter: u32 = 1;
     loop {
         match counter {
@@ -57,23 +39,21 @@ pub fn play_hand(shoe: &mut Shoe) -> f32 {
 
         match decision {
             ("h", _) => {
-                player.hand.add_card(shoe.deal().unwrap());
-                println!("Hand: {}", player.hand);
-                println!("Score: {:?}", player.hand.score());
-                if player.hand.score() > 21 {
-                    println!("Busted.");
-                    return -1.0;
+                player.add_card(shoe.deal().unwrap());
+                println!("Hand: {}", player);
+                println!("Score: {:?}", player.score());
+                if player.score() > 21 {
+                    break;
                 }
                 counter += 1;
             }
             ("d", 1) => {
                 multiplier = 2.0;
-                player.hand.add_card(shoe.deal().unwrap());
-                println!("Hand: {}", player.hand);
-                println!("Score: {:?}", player.hand.score());
-                if player.hand.score() > 21 {
-                    println!("Busted.");
-                    return -2.0;
+                player.add_card(shoe.deal().unwrap());
+                println!("Hand: {}", player);
+                println!("Score: {:?}", player.score());
+                if player.score() > 21 {
+                    break;
                 }
                 // you can only get one card when doubling down
                 break;
@@ -90,18 +70,89 @@ pub fn play_hand(shoe: &mut Shoe) -> f32 {
         }
     }
 
-    // dealer's turn
-    println!("Dealer: {}", dealer.hand);
-    while dealer.hand.score() < 17 {
-        dealer.hand.add_card(shoe.deal().unwrap());
-        println!("Dealer: {}", dealer.hand);
-    }
-    println!("Dealer score: {}", dealer.hand.score());
+    // return player hand and hand multlplier
+    // (player, multiplier)
+    // player
+    multiplier
+}
 
-    if dealer.hand.score() > 21 || player.hand.score() > dealer.hand.score() {
+fn settle_dealer_hand<'a>(shoe: &'a mut Shoe, dealer: &'a mut Hand) -> () {
+    // dealer's turn
+    println!("Dealer: {}", dealer);
+    while dealer.score() < 17 {
+        dealer.add_card(shoe.deal().unwrap());
+        println!("Dealer: {}", dealer);
+    }
+    println!("Dealer score: {}", dealer.score());
+
+    // dealer
+}
+
+pub fn play_hand(shoe: &mut Shoe) -> f32 {
+    //instantiate players
+    let mut player = Player::new();
+    let mut dealer = Player::new();
+
+    // deal initial cards
+    player.hands[0].add_card(shoe.deal().unwrap());
+    dealer.hands[0].add_card(shoe.deal().unwrap());
+    player.hands[0].add_card(shoe.deal().unwrap());
+    dealer.hands[0].add_card(shoe.deal().unwrap());
+
+    println!("Hand: {}", player.hands[0]);
+    println!("Score: {:?}", player.hands[0].score());
+
+    // print dealer's up card
+    println!("Dealer: {}", dealer.hands[0].cards[0]);
+
+    // handle blackjack
+    if player.hands[0].score() == 21 && dealer.hands[0].score() == 21 {
+        println!("Dealer: {}", dealer.hands[0]);
+        println!("Pushed blackjack!");
+        return 0.0;
+    } else if player.hands[0].score() == 21 {
+        println!("Blackjack!");
+        return 1.5;
+    }
+
+    //allow splitting
+    if player.hands[0].cards[0].rank == player.hands[0].cards[1].rank {
+        println!("Split pair? [y/n]");
+        loop {
+            let mut input = String::new();
+            io::stdin()
+                .read_line(&mut input)
+                .expect("Failed to read line");
+
+            match input.trim() {
+                "n" => {}
+                "y" => {
+                    player.hands.push(Hand { cards: vec![] });
+                    player.hands[1].add_card(player.hands[0].cards[1]);
+                    player.hands[0].add_card(shoe.deal().unwrap());
+                    player.hands[1].add_card(shoe.deal().unwrap());
+                }
+                _ => {
+                    println!("Invalid choice, yes (y) or no (n).")
+                }
+            }
+        }
+    }
+
+    let multiplier = settle_player_hand(shoe, &mut player.hands[0]);
+
+    if player.hands[0].score() > 21 {
+        println!("Busted!");
+        println!("Dealer wins!");
+        return -1.0;
+    }
+
+    settle_dealer_hand(shoe, &mut dealer.hands[0]);
+
+    if dealer.hands[0].score() > 21 || player.hands[0].score() > dealer.hands[0].score() {
         println!("Player wins!");
         return 1.0 * multiplier;
-    } else if dealer.hand.score() > player.hand.score() {
+    } else if dealer.hands[0].score() > player.hands[0].score() {
         println!("Dealer wins!");
         return -1.0 * multiplier;
     } else {


### PR DESCRIPTION
The following changes were made to allow the player to split their hand if the cards dealt to them are the same `Rank`:

- [x] make `multiplier` a field of `Hand`
- [x] create `can_split` function on `Hand`
- [x] create `split` function on `Player`
- [x] change `hand` field on `Player` to be `Vec<Hand>` 
- [x] break `play_hand` function into component parts: `settle_player_hand` and `settle_dealer_hand`